### PR TITLE
Set correct core dump default value 

### DIFF
--- a/ubuntu/system.sls
+++ b/ubuntu/system.sls
@@ -33,4 +33,5 @@ kernel.sysrq:
 # may contain sensitive information.
 fs.suid_dumpable: 
  sysctl.present: 
-  - value: 1
+  - value: 0
+


### PR DESCRIPTION
I believe you picked the wrong default value when you choose to leave out a state variable control on the SUID core dump fix. 

The current value of 1 will mean that SUID core dumps are created leaving the system open. This is the opposite of what the telekomlabs module for puppet does by default. 

This PR sets the default behavior to match the telekomlabs module
